### PR TITLE
[PoC] Workflow task middleware feature

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,6 @@
 name: Build Package
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,6 +1,7 @@
 name: Build Package
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main

--- a/src/Temporalio/Worker/IWorkflowInstance.cs
+++ b/src/Temporalio/Worker/IWorkflowInstance.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Temporalio.Bridge.Api.WorkflowActivation;
 using Temporalio.Bridge.Api.WorkflowCompletion;
 
@@ -13,6 +14,6 @@ namespace Temporalio.Worker
         /// </summary>
         /// <param name="activation">Activation to apply to workflow.</param>
         /// <returns>Completion. This should have success or fail set.</returns>
-        WorkflowActivationCompletion Activate(WorkflowActivation activation);
+        Task<WorkflowActivationCompletion> ActivateAsync(WorkflowActivation activation);
     }
 }

--- a/src/Temporalio/Worker/TemporalWorker.cs
+++ b/src/Temporalio/Worker/TemporalWorker.cs
@@ -86,7 +86,8 @@ namespace Temporalio.Worker
                     WorkflowStackTrace: options.WorkflowStackTrace,
                     OnTaskStarting: options.OnTaskStarting,
                     OnTaskCompleted: options.OnTaskCompleted,
-                    RuntimeMetricMeter: MetricMeter));
+                    RuntimeMetricMeter: MetricMeter,
+                    WorkflowTaskMiddlewarePipeline: options.WorkflowTaskMiddlewarePipeline));
             }
         }
 

--- a/src/Temporalio/Worker/WorkflowInstanceDetails.cs
+++ b/src/Temporalio/Worker/WorkflowInstanceDetails.cs
@@ -24,6 +24,7 @@ namespace Temporalio.Worker
     /// <param name="WorkflowStackTrace">Option for workflow stack trace.</param>
     /// <param name="OnTaskStarting">Callback for every instance task start.</param>
     /// <param name="OnTaskCompleted">Callback for every instance task complete.</param>
+    /// <param name="WorkflowTaskMiddlewarePipeline">Middleware pipeline for workflow task execution.</param>
     /// <param name="RuntimeMetricMeter">Lazy runtime-level metric meter.</param>
     internal record WorkflowInstanceDetails(
         string Namespace,
@@ -39,5 +40,6 @@ namespace Temporalio.Worker
         WorkflowStackTrace WorkflowStackTrace,
         Action<WorkflowInstance> OnTaskStarting,
         Action<WorkflowInstance, Exception?> OnTaskCompleted,
+        WorkflowTaskMiddlewarePipeline WorkflowTaskMiddlewarePipeline,
         Lazy<IMetricMeter> RuntimeMetricMeter);
 }

--- a/src/Temporalio/Worker/WorkflowReplayer.cs
+++ b/src/Temporalio/Worker/WorkflowReplayer.cs
@@ -172,7 +172,8 @@ namespace Temporalio.Worker
                             WorkflowStackTrace: WorkflowStackTrace.None,
                             OnTaskStarting: options.OnTaskStarting,
                             OnTaskCompleted: options.OnTaskCompleted,
-                            RuntimeMetricMeter: new(() => runtime.MetricMeter)),
+                            RuntimeMetricMeter: new(() => runtime.MetricMeter),
+                            WorkflowTaskMiddlewarePipeline: new()),
                         (runId, removeFromCache) => SetResult(removeFromCache));
                 }
                 catch

--- a/src/Temporalio/Worker/WorkflowTaskMiddlewareContext.cs
+++ b/src/Temporalio/Worker/WorkflowTaskMiddlewareContext.cs
@@ -1,0 +1,63 @@
+﻿namespace Temporalio.Worker
+{
+    using System;
+    using System.Collections.Generic;
+    using Temporalio.Workflows;
+
+    /// <summary>
+    /// Context data that can be used to share data between middleware.
+    /// </summary>
+    public record WorkflowTaskMiddlewareContext(WorkflowInfo WorkflowInfo, WorkflowDefinition WorkflowDefinition)
+    {
+        private readonly Dictionary<string, object?> customProperties = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets a key/value collection that can be used to share data between middleware.
+        /// </summary>
+        public IReadOnlyDictionary<string, object?> CustomProperties => customProperties;
+
+        /// <summary>
+        /// Sets a property value to the context using the full name of the type as the key.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="value">The value of the property.</param>
+        public void SetProperty<T>(T value)
+        {
+            string typeName = typeof(T).FullName ?? throw new InvalidOperationException("Cannot get the full name of the type.");
+            SetProperty(typeName, value);
+        }
+
+        /// <summary>
+        /// Sets a named property value to the context.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="key">The name of the property.</param>
+        /// <param name="value">The value of the property.</param>
+        public void SetProperty<T>(string key, T value)
+        {
+            customProperties[key] = value;
+        }
+
+        /// <summary>
+        /// Gets a property value from the context using the full name of <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <returns>The value of the property or <c>default(T)</c> if the property is not defined.</returns>
+        public T? GetProperty<T>()
+        {
+            string typeName = typeof(T).FullName ?? throw new InvalidOperationException("Cannot get the full name of the type.");
+            return GetProperty<T>(typeName);
+        }
+
+        /// <summary>
+        /// Gets a named property value from the context.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="key">The name of the property value.</param>
+        /// <returns>The value of the property or <c>default(T)</c> if the property is not defined.</returns>
+        public T? GetProperty<T>(string key)
+        {
+            return customProperties.TryGetValue(key, out object? value) ? (T?)value : default;
+        }
+    }
+}

--- a/src/Temporalio/Worker/WorkflowTaskMiddlewarePipeline.cs
+++ b/src/Temporalio/Worker/WorkflowTaskMiddlewarePipeline.cs
@@ -1,0 +1,56 @@
+﻿namespace Temporalio.Worker
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A function that runs in the task execution middleware pipeline.
+    /// </summary>
+    /// <param name="context">The <see cref="WorkflowTaskMiddlewareContext"/> for the task execution.</param>
+    /// <returns>A task that represents the completion of the durable task execution.</returns>
+    public delegate Task WorkflowTaskMiddlewareHandler(WorkflowTaskMiddlewareContext context);
+
+    /// <summary>
+    /// Middleware pipeline that wraps workflow task execution.
+    /// </summary>
+    internal class WorkflowTaskMiddlewarePipeline
+    {
+        private readonly IList<Func<WorkflowTaskMiddlewareHandler, WorkflowTaskMiddlewareHandler>> components =
+            new List<Func<WorkflowTaskMiddlewareHandler, WorkflowTaskMiddlewareHandler>>();
+
+        /// <summary>
+        /// Runs the middleware pipeline handler with the specified context.
+        /// </summary>
+        /// <param name="context">Contextual information about the current workflow task.</param>
+        /// <param name="handler">The final handler to execute at the end of the pipeline.</param>
+        /// <returns>A task that completes when the full pipeline has completed.</returns>
+        public Task RunAsync(WorkflowTaskMiddlewareContext context, WorkflowTaskMiddlewareHandler handler)
+        {
+            // Build the delegate chain
+            foreach (Func<WorkflowTaskMiddlewareHandler, WorkflowTaskMiddlewareHandler> component in components.Reverse())
+            {
+                handler = component(handler);
+            }
+
+            return handler(context);
+        }
+
+        /// <summary>
+        /// Adds a new middleware component to the pipeline.
+        /// </summary>
+        /// <param name="middleware">The middleware component to add.</param>
+        public void Add(Func<WorkflowTaskMiddlewareContext, Func<Task>, Task> middleware)
+        {
+            this.components.Add(next =>
+            {
+                return context =>
+                {
+                    Task SimpleNext() => next(context);
+                    return middleware(context, SimpleNext);
+                };
+            });
+        }
+    }
+}

--- a/src/Temporalio/Worker/WorkflowWorkerOptions.cs
+++ b/src/Temporalio/Worker/WorkflowWorkerOptions.cs
@@ -20,5 +20,6 @@ namespace Temporalio.Worker
         WorkflowStackTrace WorkflowStackTrace,
         Action<WorkflowInstance> OnTaskStarting,
         Action<WorkflowInstance, Exception?> OnTaskCompleted,
-        Lazy<IMetricMeter> RuntimeMetricMeter);
+        Lazy<IMetricMeter> RuntimeMetricMeter,
+        WorkflowTaskMiddlewarePipeline WorkflowTaskMiddlewarePipeline);
 }


### PR DESCRIPTION
## What was changed
This PR adds a new feature called "workflow task middleware", which allows developers to wrap workflow task activations in middleware components.

The implementation is derived from the most basic implementation of ASP.NET middleware, and mimics a feature I created for the [Durable Task Framework](https://github.com/Azure/durabletask).

Note that this feature is distinct from workflow interceptors because the middleware runs _outside_ the workflow thread. This allows workflow code to run async. However, it's still subject to the deadlock detection logic in the WorkflowWorker (default of 2 seconds).

This is an advanced feature which most developers should not need. Rather, it's designed more for those who want to integrate the Temporal worker into other runtimes (such as the Azure Functions runtime, see below).

## Why?
This is for a PoC of having Azure Functions triggers and bindings for Temporal workflows.

For my specific case, I'm using this feature to create an Azure Functions extension that allows users to run Temporal workflows and activities serverless-ly and in a way that's natively understood by the Azure Functions platform. Specifically, each workflow and activity invocation (or "task", or even "activation", depending on which terminology you want to use) needs to be treated as a separate function invocation for the purposes of Azure Functions-specific timeout management, metering, billing, logging, etc.  

In summary, this feature allows me to wrap Temporal workflow activations in the Azure Functions execution pipeline. It's not needed for activities, only for workflows.

## Checklist
<!--- add/delete as needed --->

1. Closes (no issue opened)

2. How was this tested:
Manually, with both a simple console app and a real Azure Function app

3. Any docs updates needed?
Not unless we want to actually ship this.